### PR TITLE
Fix a wrong "-config" switch in the service configuration files

### DIFF
--- a/heketi.initd
+++ b/heketi.initd
@@ -46,7 +46,7 @@ start() {
         chown ${user}:${user} $pidfile
 
         echo -n "Starting $prog: "
-        daemon --user heketi "$exec -config=${config} &>> $logfile & echo \$! > $pidfile"
+        daemon --user heketi "$exec --config=${config} &>> $logfile & echo \$! > $pidfile"
         retval=$?
         if [ $retval -eq 0 ] ; then
             touch $lockfile

--- a/heketi.service
+++ b/heketi.service
@@ -6,7 +6,7 @@ Type=simple
 WorkingDirectory=/var/lib/heketi
 EnvironmentFile=-/etc/heketi/heketi.json
 User=heketi
-ExecStart=/usr/bin/heketi -config=/etc/heketi/heketi.json
+ExecStart=/usr/bin/heketi --config=/etc/heketi/heketi.json
 Restart=on-failure
 StandardOutput=syslog
 StandardError=syslog

--- a/heketi.spec
+++ b/heketi.spec
@@ -33,7 +33,7 @@
 
 Name:           %{repo}
 Version:        5.0.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        RESTful based volume management framework for GlusterFS
 License:        LGPLv3+ and GPLv2
 URL:            https://%{provider_prefix}
@@ -392,6 +392,9 @@ getent passwd %{name} >/dev/null || useradd -r -g %{name} -d %{_sharedstatedir}/
 %endif
 
 %changelog
+* Sat Feb 17 2018 Alessandro Menti <alessandro.menti@alessandromenti.it> - 5.0.1-2
+- Fix a wrong "-config" switch in the service configuration files
+
 * Tue Dec 19 2017 Niels de Vos <ndevos@redhat.com> - 5.0.1-1
 - Release 5.0.1 final
 


### PR DESCRIPTION
In the systemd and initd configuration files, Heketi is started with a `-config` switch. The command line syntax was changed a while ago: the program now requires two dashes in front of the options (e.g. `--config`), otherwise it will not start.

This pull request updates the systemd/initd configuration files accordingly.